### PR TITLE
Add a MANIFEST.in file to include *.rst, *.md and *.txt files into sdist package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+include *.md
+include *.rst
+include *.txt
+
+include ChangeLog
+include MakeFile
+
+global-exclude *.pyc
+global-exclude .gitignore
+global-exclude .DS_Store


### PR DESCRIPTION
Global excludes set to:
- `*.pyc`
- `.gitignore`
- `.DS_Store`

This fixes #5 and #6 
