### PR TITLE
Added quit() method.

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -291,6 +291,10 @@ class Client(local):
 
         return(data)
 
+    def quit(self):
+        for s in self.servers:
+            s.quit()
+
     def get_slabs(self):
         data = []
         for s in self.servers:
@@ -1214,6 +1218,12 @@ class _Host(object):
                         'read returned 0 length bytes' % ( len(buf), rlen ))
         self.buffer = buf[rlen:]
         return buf[:rlen]
+
+    def quit(self):
+        if self.socket:
+            self.send_cmd('quit')
+            self.socket.recv(1)
+            self.close_socket()
 
     def flush(self):
         self.send_cmd('flush_all')


### PR DESCRIPTION
Simply closing a connected socket leaves the local socket in TIME_WAIT while the OS waits to ensure that the remote end isn't going to transmit anything further.  Memcached supports the 'quit' command, which tells the remote server to initiate the connection close instead.  This pull request adds a quit() method to _Host that sends a quit command, waits for the remote end to close the connection, then closes the local socket (leaving behind nothing for the OS to clean up).  The quit method on Client simply calls quit() on each of the connected servers (wasn't sure whether to name it quit() or quit_all(), so went with the simpler of the two).
