### PR TITLE
feat(tox): add support for testing with tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 /dist
 /python_memcached.egg-info
+.tox

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## Overview
+
 This software is a 100% Python interface to the memcached memory cache
 daemon.  It is the client side software which allows storing values in one
 or more, possibly remote, memcached servers.  Search google for memcached
@@ -14,3 +16,14 @@ Please report issues and submit code changes to the github repository at:
 For changes prior to 2013-03-26, see the old Launchpad repository at:
 
    Historic issues: https://launchpad.net/python-memcached
+
+## Testing
+
+Test patches locally and easily by running tox:
+
+    pip install tox
+    tox -e py27
+
+Test for style by running tox:
+
+    tox -e pep8

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,0 @@
-TESTS = $(wildcard test_*.py)
-
-test:
-	@- $(foreach TEST,$(TESTS), \
-		echo === Running test: $(TEST); \
-		python $(TEST); \
-		)

--- a/tests/test_setmulti.py
+++ b/tests/test_setmulti.py
@@ -63,5 +63,3 @@ class test_Memcached_Set_Multi(unittest.TestCase):
 
         if DEBUG:
             print 'set_multi({0!r}) -> {1!r}'.format(mapping, bad_keys)
-
-unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+minversion = 1.6
+envlist = py26,py27,py33,pypy,pep8
+skipsdist = True
+
+[testenv]
+usedevelop = True
+# Customize pip command, add -U to force updates.
+install_command = pip install -U {opts} {packages}
+deps = nose
+commands = nosetests {posargs}
+
+[tox:jenkins]
+downloadcache = ~/cache/pip
+
+[testenv:pep8]
+deps = hacking
+commands = flake8
+
+[testenv:cover]
+deps = nose
+       coverage
+commands = nosetests --with-coverage {posargs}
+
+[flake8]
+exclude = .venv*,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*.egg,.update-venv


### PR DESCRIPTION
This adds notes in the README and a tox.ini file for use with the tox
test manager.

This helps greatly towards migrating python-memcached towards python
3.3+ compatibility.
