### PR TITLE
Allow specifying an empty server list.

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -352,6 +352,9 @@ class Client(local):
         else:
             serverhash = serverHashFunction(key)
 
+        if not self.buckets:
+            return None, None
+
         for i in range(Client._SERVER_RETRIES):
             server = self.buckets[serverhash % len(self.buckets)]
             if server.connect():


### PR DESCRIPTION
If the server list is empty, behave the same as if all servers are down.
This allows clients to not care whether memcache is actually in use:

mc = memcache.Client(get_my_memcache_servers())
mc.get('cache')

If you're not using memcache at all, get_my_memcache_servers() just
returns [], and the client code doesn't need to know the difference.
Previously, it would fail:

> > > mc = memcache.Client([])
> > > mc.get('x')
> > >   File "memcache.py", line 353, in _get_server
> > >     server = self.buckets[serverhash % len(self.buckets)]
> > > ZeroDivisionError: integer division or modulo by zero
