### PR TITLE
Fix an `except` for Py3

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -448,7 +448,7 @@ class Client(threading.local):
         should fail. Defaults to None for no delay.
         @rtype: int
         '''
-        return self._deletetouch(['DELETED','NOT_FOUND'], "delete", key, time)
+        return self._deletetouch(['DELETED', 'NOT_FOUND'], "delete", key, time)
 
     def touch(self, key, time=0):
         '''Updates the expiration time of a key in memcache.
@@ -480,8 +480,8 @@ class Client(threading.local):
             line = server.readline()
             if line and line.strip() in expected:
                 return 1
-            self.debuglog('%s expected %s, got: %s'
-                    % (cmd, ' or '.join(expected), repr(line)))
+            self.debuglog('%s expected %s, got: %r'
+                          % (cmd, ' or '.join(expected), line))
         except socket.error as msg:
             if isinstance(msg, tuple):
                 msg = msg[1]


### PR DESCRIPTION
It appears to have been introduced with the merge of PR #28 and I guess PR #26 was created before this and didn't handle it.

I think we're not seeing the failure in Travis CI only because the Travis CI jobs are failing first with the problem addressed in https://github.com/linsomniac/python-memcached/pull/34

Cc: @linsomniac, @cabrera
