### PR TITLE
.travis.yml: Add Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 2.6
   - 2.7
   - pypy
+  - 3.3
 install: python setup.py install
 before_script: pip install nose
 script: nosetests


### PR DESCRIPTION
Adds Python 3.3 to Travis.

``` diff
diff --git a/.travis.yml b/.travis.yml
index 3a3a3f2..e5753a9 100644
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 2.6
   - 2.7
   - pypy
+  - 3.3
 install: python setup.py install
 before_script: pip install nose
 script: nosetests
```
