### PR TITLE
Bug-fix, Python3 support, and raise an exception when _get_server() fails.

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -26,7 +26,7 @@ This should give you a feel for how this module operates::
     mc.incr("key")
     mc.decr("key")
 
-The standard way to use memcache with a database is like this::
+The standard way to use memcache with a database is like this:
 
     key = derive_key(obj)
     obj = mc.get(key)
@@ -116,6 +116,9 @@ class _Error(Exception):
 class _ConnectionDeadError(Exception):
     pass
 
+
+class NoServerAvailable(Exception):
+    pass
 
 try:
     # Only exists in Python 2.4+
@@ -376,7 +379,8 @@ class Client(local):
                 #print("(using server %s)" % server)
                 return server, key
             serverhash = serverHashFunction(str(serverhash) + str(i))
-        return None, None
+        
+        raise NoServerAvailable()
 
     def disconnect_all(self):
         for s in self.servers:


### PR DESCRIPTION
I added a bug-fix for a crash that occurs when _get_socket() experiences a _socket.error_. I also added Python3 support, and I took the opportunity to just throw a NoServerAvailable exception (which I added) when no server connection could be elected. You may or may not want this, but it'll behave more like people might expect it to under failure, and we'll also be able to remove some boilerplate code from every operation that checks for a (None, None) return.
