### PR TITLE
Fixed server enumeration logic

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -384,14 +384,12 @@ class Client(threading.local):
         else:
             serverhash = serverHashFunction(key)
 
-        indices = reduce(lambda a, (i, server): a + (i,) * server.weight,
-                         enumerate(self.servers), tuple())
-        while indices:
-            serverindex = indices[serverhash % len(indices)]
-            server = self.servers[serverindex]
+        buckets = tuple(self.buckets)
+        while buckets:
+            server = buckets[serverhash % len(buckets)]
             if server.connect():
                 return server, key
-            indices = filter(lambda x: x != serverindex, indices)
+            buckets = filter(lambda x: x != server, buckets)
         return None, None
 
     def disconnect_all(self):


### PR DESCRIPTION
Created with a list of memcache servers client has non-zero chance
to fail any operation involving server selection due to _get_server()
sometimes fails to find single alive server among dead ones.

Changed server search routine to perform each new server search
excluding dead server.

More detailed description here:
https://bugs.launchpad.net/mos/+bug/1370324
