### PR TITLE
Port memcache to Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ python:
   - 3.3
   - 3.4
   - pypy
-matrix:
-  allow_failures:
-    - python: 3.2
-    - python: 3.3
-    - python: 3.4
 services:
   - memcached
 install: python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(name="python-memcached",
           "Programming Language :: Python :: 2",
           "Programming Language :: Python :: 2.6",
           "Programming Language :: Python :: 2.7",
-#          "Programming Language :: Python :: 3",
-#          "Programming Language :: Python :: 3.2",
-#          "Programming Language :: Python :: 3.3",
-#          "Programming Language :: Python :: 3.4"
+          "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3.2",
+          "Programming Language :: Python :: 3.3",
+          "Programming Language :: Python :: 3.4"
           ])

--- a/tests/test_memcache.py
+++ b/tests/test_memcache.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 
 from unittest import TestCase
 
+import six
+
 from memcache import Client, SERVER_MAX_KEY_LENGTH
 
 try:
@@ -135,14 +137,14 @@ if __name__ == "__main__":
 
         print("Testing sending a unicode-string key...", end=" ")
         try:
-            x = mc.set(u'keyhere', 1)
+            x = mc.set(six.u('keyhere'), 1)
         except Client.MemcachedStringEncodingError as msg:
             print("OK", end=" ")
         else:
             print("FAIL", end=" ")
             failures += 1
         try:
-            x = mc.set((u'a'*SERVER_MAX_KEY_LENGTH).encode('utf-8'), 1)
+            x = mc.set((six.u('a')*SERVER_MAX_KEY_LENGTH).encode('utf-8'), 1)
         except Client.MemcachedKeyError:
             print("FAIL", end=" ")
             failures += 1

--- a/tests/test_setmulti.py
+++ b/tests/test_setmulti.py
@@ -21,7 +21,7 @@ DEBUG = False
 
 class test_Memcached_Set_Multi(unittest.TestCase):
     def setUp(self):
-        RECV_CHUNKS = ['chunk1']
+        RECV_CHUNKS = [b'chunk1']
 
         class FakeSocket(object):
             def __init__(self, *args):


### PR DESCRIPTION
* Encode unicode key to UTF-8: add _encode_key() method
* Add _encode_cmd() helper method to format a memcache command as a byte string (bytes%args will only be supported in Python 3.5)
* Rewrite _map_and_prefix_keys() code converting keys
* _val_to_store_info() now accepts Unicode: Unicode is encoded to UTF-8
* _set('cas') doesn't call _val_to_store_info() anymore when it's not needed: begin by checking if the key is in the cas_ids dictionary
* Process server reply as bytes
* _recv_value() now clears the _FLAG_COMPRESSED flag after decompressing to simplify the code
* On Python 3, _recv_value() now decodes byte strings from UTF-8
* Simplify check_key(), _encode_key() now encodes Unicode to UTF-8