### PR TITLE
removed ascii-encoding for cache key

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -61,9 +61,7 @@ import six
 
 
 def cmemcache_hash(key):
-    return (
-        (((binascii.crc32(key.encode('ascii')) & 0xffffffff)
-          >> 16) & 0x7fff) or 1)
+    return ((((binascii.crc32(key) & 0xffffffff) >> 16) & 0x7fff) or 1)
 serverHashFunction = cmemcache_hash
 
 


### PR DESCRIPTION
It doesn't seem necessary to encode the key ascii when crc32 doesn't care about the actual data format or encoding, and this operation is causing non-ascii keys to fail when it's not recognised by the ascii encoder.