### PR TITLE
Fix recently-introduced encoding/decoding bugs.

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -143,6 +143,7 @@ class Client(threading.local):
     _FLAG_INTEGER = 1 << 1
     _FLAG_LONG = 1 << 2
     _FLAG_COMPRESSED = 1 << 3
+    _FLAG_TEXT = 1 << 4
 
     _SERVER_RETRIES = 10  # how many times to try finding a free server.
 
@@ -931,6 +932,7 @@ class Client(threading.local):
         if isinstance(val, six.binary_type):
             pass
         elif isinstance(val, six.text_type):
+            flags |= Client._FLAG_TEXT
             val = val.encode('utf-8')
         elif isinstance(val, int):
             flags |= Client._FLAG_INTEGER
@@ -1226,11 +1228,10 @@ class Client(threading.local):
             flags &= ~Client._FLAG_COMPRESSED
 
         if flags == 0:
-            # Bare string
-            if six.PY3:
-                val = buf.decode('utf8')
-            else:
-                val = buf
+            # Bare bytes
+            val = buf
+        elif flags & Client._FLAG_TEXT:
+            val = buf.decode('utf8')
         elif flags & Client._FLAG_INTEGER:
             val = int(buf)
         elif flags & Client._FLAG_LONG:

--- a/memcache.py
+++ b/memcache.py
@@ -929,19 +929,23 @@ class Client(threading.local):
         the new value itself.
         """
         flags = 0
-        if isinstance(val, six.binary_type):
+        # Check against the exact type, rather than using isinstance, so that
+        # subclasses of native types (such as markup-safe strings) are pickled
+        # and restored as instances of the correct class.
+        type_ = type(val)
+        if type_ == six.binary_type:
             pass
-        elif isinstance(val, six.text_type):
+        elif type_ == six.text_type:
             flags |= Client._FLAG_TEXT
             val = val.encode('utf-8')
-        elif isinstance(val, int):
+        elif type_ == int:
             flags |= Client._FLAG_INTEGER
             val = str(val)
             if six.PY3:
                 val = val.encode('ascii')
             # force no attempt to compress this silly string.
             min_compress_len = 0
-        elif six.PY2 and isinstance(val, long):
+        elif six.PY2 and type_ == long:
             flags |= Client._FLAG_LONG
             val = str(val)
             if six.PY3:


### PR DESCRIPTION
This mainly fixes two encoding/decoding bugs that were introduced since 1.53:
- `unicode` values are not properly decoded when retrieved on Python 2, and `bytes` values are improperly decoded as UTF-8 when retrieved on Python 3.
- Values with types which inherit from `unicode` (e.g., `markupsafe.Markup`) are pickled as plain unicode values, rather than as the derived type.

I also ran into quite a lot of issues after I added tests, and tried to run them on Python 3. It seems that a lot of things were broken there, so the final commit which adds tests, also fixes existing test failures.
