### PR TITLE
(#72) setup.py will now pull the version number directly from memcach…

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -90,7 +90,7 @@ valid_key_chars_re = re.compile(b'[\x21-\x7e\x80-\xff]+$')
 
 #  Original author: Evan Martin of Danga Interactive
 __author__ = "Sean Reifschneider <jafo-memcached@tummy.com>"
-__version__ = "1.57"
+__version__ = "1.58"
 __copyright__ = "Copyright (C) 2003 Danga Interactive"
 #  http://en.wikipedia.org/wiki/Python_Software_Foundation_License
 __license__ = "Python Software Foundation License"

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
+from setuptools.depends import get_module_constant
 from setuptools import setup  # noqa
 
 
 setup(name="python-memcached",
-      version="1.58",
+      version=get_module_constant('memcache', '__version__'),
       description="Pure python memcached client",
       long_description=open("README.md").read(),
       author="Evan Martin",


### PR DESCRIPTION
…e.py (using setuptools.depends.get_module_constant) in order to prevent discrepancies

```
Python 2.7.3 (default, Mar 13 2014, 11:03:55) 
[GCC 4.7.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import memcache
>>> memcache.__version__
'1.58'
>>> import pkg_resources
>>> pkg_resources.require('python-memcached')[0].version
'1.58'
```