### PR TITLE
Use cPickle with Python 2 again, to fix v1.54 performance regression

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -49,7 +49,6 @@ from __future__ import print_function
 
 import binascii
 import os
-import pickle
 import re
 import socket
 import sys
@@ -58,6 +57,12 @@ import time
 import zlib
 
 import six
+
+if six.PY2:
+    # With Python 2, the faster C implementation has to be imported explicitly.
+    import cPickle as pickle
+else:
+    import pickle
 
 
 def cmemcache_hash(key):


### PR DESCRIPTION
Some Python 3 compatibility changes made python-memcached import `pickle` rather than `cPickle`, since the latter isn't available on Python 3:
https://github.com/linsomniac/python-memcached/commit/45403325e0249ff0f61d6ae449a7daeeb7e852e5

This is fine on Python 3, since importing `pickle` will automatically use the faster C implementation if available, however with Python 2 this caused a 400% slowdown in memcache gets between python-memcached v1.53 and v1.54, when dealing with objects other than bytes.

This mostly fixes #71, though there is still a 10-20% performance drop using current master plus this change, compared to v1.53 (using Python 2.7.10).