### PR TITLE
Python3: `get_stats` function fails due to Bytestring encoding errors

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -333,9 +333,9 @@ class Client(threading.local):
             readline = s.readline
             while 1:
                 line = readline()
-                if not line or line.strip() == 'END':
+                if not line or line.decode('ascii').strip() == 'END':
                     break
-                stats = line.split(' ', 2)
+                stats = line.decode('ascii').split(' ', 2)
                 serverData[stats[1]] = stats[2]
 
         return(data)


### PR DESCRIPTION
Pull request fix the Python3 Bytestring decoding error in `get_stats` method, however tests are still missing. (And generally missing for the `get_stats` method.)

#87 is related, however I prefer the decoding over the bytestring casting, since thats is how its used everywhere else.
