### PR TITLE
Fix set_multi method when all items in mapping are greater than…

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -910,6 +910,7 @@ class Client(threading.local):
         # send out all requests on each server before reading anything
         dead_servers = []
         notstored = []  # original keys.
+        has_valid_content = False
 
         for server in six.iterkeys(server_keys):
             bigcmd = []
@@ -926,6 +927,7 @@ class Client(threading.local):
                                                    noreply,
                                                    b'\r\n', val, b'\r\n')
                         write(fullcmd)
+                        has_valid_content = True
                     else:
                         notstored.append(prefixed_to_orig_key[key])
                 server.send_cmds(b''.join(bigcmd))
@@ -937,6 +939,9 @@ class Client(threading.local):
 
         # if noreply, just return early
         if noreply:
+            return notstored
+
+        if not has_valid_content:
             return notstored
 
         # if any servers died on the way, don't expect them to respond.


### PR DESCRIPTION
… self.server_max_value_length. When it happens, servers are marked as dead and next commands will for some seconds (according to _DEAD_RETRY value)