### PR TITLE
Remove testing for Python 3.3 and add testing for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
   - pypy
 services:
   - memcached

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - pypy

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-   *  Added testing for Python 3.5 (PR from Tim Graham) #110
+   *  Added testing for Python 3.5 and 3.6 (PR from Tim Graham) #110, #131
 
    *  Fixed typos in docstrings (PR from Romuald Brunet, reviewed by Tim
       Graham) #105

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,7 @@
    *  Fixed typos in docstrings (PR from Romuald Brunet, reviewed by Tim
       Graham) #105
 
-   *  Removing Python 2.6 and 3.2 testing (PR from Tim Graham) #115
+   *  Removing Python 2.6, 3.2, and 3.3 testing (PR from Tim Graham) #115, #116
 
    *  Removing unnecessary parens in return statements (PR from Tim Graham)
       #113

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ setup(name="python-memcached",
           "Programming Language :: Python :: 3",
           "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
+          "Programming Language :: Python :: 3.6",
           ])

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(name="python-memcached",
           "Programming Language :: Python :: 2",
           "Programming Language :: Python :: 2.7",
           "Programming Language :: Python :: 3",
-          "Programming Language :: Python :: 3.3",
           "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
           ])

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27,py34,py35,pypy,pep8
+envlist = py27,py34,py35,p36,pypy,pep8
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27,py33,py34,py35,pypy,pep8
+envlist = py27,py34,py35,pypy,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
It's end of life in September 2017.