### PR TITLE
Add raw_bytes option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /python_memcached.egg-info
 .tox
 .coverage
+.idea

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+   *  Added `raw_bytes` option to avoid decoding bytes to str
+
    *  Added testing for Python 3.5 (PR from Tim Graham) #110
 
    *  Fixed typos in docstrings (PR from Romuald Brunet, reviewed by Tim

--- a/memcache.py
+++ b/memcache.py
@@ -176,7 +176,8 @@ class Client(threading.local):
                  pload=None, pid=None,
                  server_max_key_length=None, server_max_value_length=None,
                  dead_retry=_DEAD_RETRY, socket_timeout=_SOCKET_TIMEOUT,
-                 cache_cas=False, flush_on_reconnect=0, check_keys=True):
+                 cache_cas=False, flush_on_reconnect=0, check_keys=True,
+                 raw_bytes=False):
         """Create a new Client object with the given list of servers.
 
         @param servers: C{servers} is passed to L{set_servers}.
@@ -219,6 +220,8 @@ class Client(threading.local):
         @param check_keys: (default True) If True, the key is checked
         to ensure it is the correct length and composed of the right
         characters.
+        @param raw_bytes: (default False) if True, we return raw
+        bytes instead of trying to decode to Unicode string.
         """
         super(Client, self).__init__()
         self.debug = debug
@@ -230,6 +233,7 @@ class Client(threading.local):
         self.cache_cas = cache_cas
         self.reset_cas()
         self.do_check_key = check_keys
+        self.raw_bytes = raw_bytes
 
         # Allow users to modify pickling/unpickling behavior
         self.pickleProtocol = pickleProtocol
@@ -1267,7 +1271,7 @@ class Client(threading.local):
 
         if flags == 0:
             # Bare string
-            if six.PY3:
+            if not self.raw_bytes and six.PY3:
                 val = buf.decode('utf8')
             else:
                 val = buf

--- a/memcache.py
+++ b/memcache.py
@@ -95,7 +95,7 @@ valid_key_chars_re = re.compile(b'[\x21-\x7e\x80-\xff]+$')
 
 #  Original author: Evan Martin of Danga Interactive
 __author__ = "Sean Reifschneider <jafo-memcached@tummy.com>"
-__version__ = "1.58"
+__version__ = "1.58.2"
 __copyright__ = "Copyright (C) 2003 Danga Interactive"
 #  http://en.wikipedia.org/wiki/Python_Software_Foundation_License
 __license__ = "Python Software Foundation License"

--- a/memcache.py
+++ b/memcache.py
@@ -1041,8 +1041,8 @@ class Client(threading.local):
                 server.send_cmd(fullcmd)
                 if noreply:
                     return True
-                returnserver.expect(b"STORED", raise_exception=True)
-                       == b"STORED"
+                return (server.expect(b"STORED", raise_exception=True)
+                        == b"STORED")
             except socket.error as msg:
                 if isinstance(msg, tuple):
                     msg = msg[1]

--- a/memcache.py
+++ b/memcache.py
@@ -78,9 +78,10 @@ def useOldServerHashFunction():
 
 valid_key_chars_re = re.compile(b'[\x21-\x7e\x80-\xff]+$')
 
+
 #  Original author: Evan Martin of Danga Interactive
 __author__ = "Sean Reifschneider <jafo-memcached@tummy.com>"
-__version__ = "1.58.2"
+__version__ = "1.58"
 __copyright__ = "Copyright (C) 2003 Danga Interactive"
 #  http://en.wikipedia.org/wiki/Python_Software_Foundation_License
 __license__ = "Python Software Foundation License"

--- a/memcache.py
+++ b/memcache.py
@@ -66,9 +66,7 @@ else:
 
 
 def cmemcache_hash(key):
-    return (
-        ((binascii.crc32(key) & 0xffffffff)
-          >> 16) & 0x7fff) or 1
+    return (((binascii.crc32(key) & 0xffffffff) >> 16) & 0x7fff) or 1
 serverHashFunction = cmemcache_hash
 
 
@@ -248,7 +246,7 @@ class Client(threading.local):
     def _encode_key(self, key):
         if isinstance(key, tuple):
             if isinstance(key[1], six.text_type):
-                return key[0], key[1].encode('utf8')
+                return (key[0], key[1].encode('utf8'))
         elif isinstance(key, six.text_type):
             return key.encode('utf8')
         return key
@@ -832,7 +830,7 @@ class Client(threading.local):
             server_keys[server].append(key)
             prefixed_to_orig_key[key] = orig_key
 
-        return server_keys, prefixed_to_orig_key
+        return (server_keys, prefixed_to_orig_key)
 
     def set_multi(self, mapping, time=0, key_prefix='', min_compress_len=0,
                   noreply=False):
@@ -1007,7 +1005,7 @@ class Client(threading.local):
                     len(val) > self.server_max_value_length):
             return 0
 
-        return flags, len(val), val
+        return (flags, len(val), val)
 
     def _set(self, cmd, key, val, time, min_compress_len=0, noreply=False):
         key = self._encode_key(key)
@@ -1041,8 +1039,7 @@ class Client(threading.local):
                 server.send_cmd(fullcmd)
                 if noreply:
                     return True
-                return (server.expect(b"STORED", raise_exception=True)
-                        == b"STORED")
+                return server.expect(b"STORED", raise_exception=True) == b"STORED"
             except socket.error as msg:
                 if isinstance(msg, tuple):
                     msg = msg[1]
@@ -1228,9 +1225,9 @@ class Client(threading.local):
 
         if line and line[:5] == b'VALUE':
             resp, rkey, flags, len, cas_id = line.split()
-            return rkey, int(flags), int(len), int(cas_id)
+            return (rkey, int(flags), int(len), int(cas_id))
         else:
-            return None, None, None, None
+            return (None, None, None, None)
 
     def _expectvalue(self, server, line=None, raise_exception=False):
         if not line:
@@ -1240,9 +1237,9 @@ class Client(threading.local):
             resp, rkey, flags, len = line.split()
             flags = int(flags)
             rlen = int(len)
-            return rkey, flags, rlen
+            return (rkey, flags, rlen)
         else:
-            return None, None, None
+            return (None, None, None)
 
     def _recv_value(self, server, flags, rlen):
         rlen += 2  # include \r\n
@@ -1324,6 +1321,7 @@ class Client(threading.local):
 
 
 class _Host(object):
+
     def __init__(self, host, debug=0, dead_retry=_DEAD_RETRY,
                  socket_timeout=_SOCKET_TIMEOUT, flush_on_reconnect=0):
         self.dead_retry = dead_retry
@@ -1403,18 +1401,16 @@ class _Host(object):
             s.connect(self.address)
         except socket.timeout as msg:
             s.close()
-            # print("timeout! %s" % (msg,))
             self.mark_dead("connect: %s" % msg)
             return None
         except socket.error as msg:
             s.close()
             if isinstance(msg, tuple):
                 msg = msg[1]
-            # print("error! %s" % (msg,))
             self.mark_dead("connect: %s" % msg)
             return None
         except Exception as e:
-            print("Other error: %s" % (e,))
+            # print("Other error: %s" % (e,))
             self.debuglog("Other error: %s" % (e,))
             raise
         self.socket = s
@@ -1521,5 +1517,6 @@ def _doctest():
     print("Doctests: %s" % (results,))
     if results.failed:
         sys.exit(1)
+
 
 # vim: ts=4 sw=4 et :

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
-from setuptools.depends import get_module_constant
+# from setuptools.depends import get_module_constant
 from setuptools import setup  # noqa
 
 
 setup(name="python-memcached",
-      version=get_module_constant('memcache', '__version__'),
+      # version=get_module_constant('memcache', '__version__'),
+      version='1.58.2',
       description="Pure python memcached client",
       long_description=open("README.md").read(),
       author="Evan Martin",

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-# from setuptools.depends import get_module_constant
+from setuptools.depends import get_module_constant
 from setuptools import setup  # noqa
 
 
 setup(name="python-memcached",
-      # version=get_module_constant('memcache', '__version__'),
-      version='1.58.2',
+      version=get_module_constant('memcache', '__version__'),
       description="Pure python memcached client",
       long_description=open("README.md").read(),
       author="Evan Martin",


### PR DESCRIPTION
For my purposes I need raw bytes from memcache. I'll do my own decoding as needed.

This PR adds a `raw_bytes` kwargs.

Also fixes some unclosed socket warnings. Tested on Python 3.6.2.
