### PR TITLE
Fix Python 3 TypeError: sequence item 0: expected str instance, bytes found on call to self.debuglog 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /python_memcached.egg-info
 .tox
 .coverage
+.idea
+lastfailed

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ before_script: pip install -r test-requirements.txt
 script:
   - flake8
   - nosetests
+  - python -c 'import memcache; memcache._doctest()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
   - pypy
 services:
   - memcached

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - pypy

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-   *  Added testing for Python 3.5 (PR from Tim Graham) #110
+   *  Added testing for Python 3.5 and 3.6 (PR from Tim Graham) #110, #131
 
    *  Fixed typos in docstrings (PR from Romuald Brunet, reviewed by Tim
       Graham) #105

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,7 @@
    *  Fixed typos in docstrings (PR from Romuald Brunet, reviewed by Tim
       Graham) #105
 
-   *  Removing Python 2.6 and 3.2 testing (PR from Tim Graham) #115
+   *  Removing Python 2.6, 3.2, and 3.3 testing (PR from Tim Graham) #115, #116
 
    *  Removing unnecessary parens in return statements (PR from Tim Graham)
       #113

--- a/memcache.py
+++ b/memcache.py
@@ -566,7 +566,7 @@ class Client(threading.local):
             if line and line.strip() in expected:
                 return 1
             self.debuglog('%s expected %s, got: %r'
-                          % (cmd, ' or '.join(expected), line))
+                          % (cmd, b' or '.join(expected), line))
         except socket.error as msg:
             if isinstance(msg, tuple):
                 msg = msg[1]

--- a/memcache.py
+++ b/memcache.py
@@ -834,9 +834,9 @@ class Client(threading.local):
         '''Sets multiple keys in the memcache doing just one query.
 
         >>> notset_keys = mc.set_multi({'key1' : 'val1', 'key2' : 'val2'})
-        >>> mc.get_multi(['key1', 'key2']) == {'key1' : 'val1',
-        ...                                    'key2' : 'val2'}
-        1
+        >>> keys = mc.get_multi(['key1', 'key2'])
+        >>> keys == {'key1': 'val1', 'key2': 'val2'}
+        True
 
 
         This method is recommended over regular L{set} as it lowers
@@ -856,14 +856,13 @@ class Client(threading.local):
             sending to memcache. Allows you to efficiently stuff these
             keys into a pseudo-namespace in memcache:
 
-            >> notset_keys = mc.set_multi(
+            >>> notset_keys = mc.set_multi(
             ...     {'key1' : 'val1', 'key2' : 'val2'},
             ...     key_prefix='subspace_')
             >>> len(notset_keys) == 0
             True
-            >>> mc.get_multi(['subspace_key1',
-            ...               'subspace_key2']) == {'subspace_key1': 'val1',
-            ...                                     'subspace_key2' : 'val2'}
+            >>> keys = mc.get_multi(['subspace_key1', 'subspace_key2'])
+            >>> keys == {'subspace_key1': 'val1', 'subspace_key2': 'val2'}
             True
 
             Causes key 'subspace_key1' and 'subspace_key2' to be

--- a/memcache.py
+++ b/memcache.py
@@ -1141,7 +1141,7 @@ class Client(threading.local):
         ...              key_prefix='pfx_') == {'k1' : 1, 'k2' : 2}
         1
 
-        get_mult [ and L{set_multi} ] can take str()-ables like ints /
+        get_multi [ and L{set_multi} ] can take str()-ables like ints /
         longs as keys too. Such as your db pri key fields.  They're
         rotored through str() before being passed off to memcache,
         with or without the use of a key_prefix.  In this mode, the

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ setup(name="python-memcached",
           "Programming Language :: Python :: 3",
           "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
+          "Programming Language :: Python :: 3.6",
           ])

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(name="python-memcached",
           "Programming Language :: Python :: 2",
           "Programming Language :: Python :: 2.7",
           "Programming Language :: Python :: 3",
-          "Programming Language :: Python :: 3.3",
           "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
           ])

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 nose
 coverage
 hacking
+mock

--- a/tests/test_memcache.py
+++ b/tests/test_memcache.py
@@ -1,10 +1,10 @@
 from __future__ import print_function
 
+import mock
+import six
 import unittest
 
-import six
-
-from memcache import Client, SERVER_MAX_KEY_LENGTH, SERVER_MAX_VALUE_LENGTH  # noqa: H301
+from memcache import Client, _Host, SERVER_MAX_KEY_LENGTH, SERVER_MAX_VALUE_LENGTH  # noqa: H301
 
 
 class FooStruct(object):
@@ -165,6 +165,13 @@ class TestMemcache(unittest.TestCase):
         self.mc.disconnect_all()
         ret = self.mc.delete_multi({'keyhere': 'a', 'keythere': 'b'})
         self.assertEqual(ret, 1)
+
+    @mock.patch.object(_Host, 'readline')
+    def test_memcached_error_unexpected_reply(self, mock_readline):
+        """Test that the debug log executes properly in error response."""
+        mock_readline.return_value = 'SET'
+        cache_key = ':cache:key:1'
+        self.mc.touch(cache_key)
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27,py34,py35,pypy,pep8
+envlist = py27,py34,py35,p36,pypy,pep8
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27,py33,py34,py35,pypy,pep8
+envlist = py27,py34,py35,pypy,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
expected is a list of bytestrings which cannot be joined with the string ' or ' so the fix is to make that string a bytestring anyway since the expected argument is always an array of bytestrings.  

The original issue is that memcached responds in an unexpected way and then the application blows up on the debuglog line with:  TypeError: sequence item 0: expected str instance, bytes found.