### PR TITLE
Fix touch(..., time=0) sending invalid command to memcache

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,8 @@
    * Fixed storing non-ASCII values on Python 2 and binary values on Python 3
      (PR from Nicolas Noé) #135
 
+   * Fixed touch(..., time=0) command (PR from Nicolas Noé) #137
+
 Fri, 27 May 2016 13:44:55 -0600  Sean Reifschneider  <jafo@tummy.com>
 
    *  1.58 release.

--- a/memcache.py
+++ b/memcache.py
@@ -553,7 +553,7 @@ class Client(threading.local):
         if not server:
             return 0
         self._statlog(cmd)
-        if time is not None and time != 0:
+        if time is not None:
             headers = str(time)
         else:
             headers = None

--- a/tests/test_memcache.py
+++ b/tests/test_memcache.py
@@ -51,6 +51,13 @@ class TestMemcache(unittest.TestCase):
         self.assertEqual(result, True)
         self.assertEqual(self.mc.get("long"), None)
 
+    @mock.patch.object(_Host, 'send_cmd')
+    @mock.patch.object(_Host, 'readline')
+    def test_touch(self, mock_readline, mock_send_cmd):
+        with captured_stderr():
+            self.mc.touch('key')
+        mock_send_cmd.assert_called_with(b'touch key 0')
+
     def test_get_multi(self):
         self.check_setget("gm_a_string", "some random string")
         self.check_setget("gm_an_integer", 42)


### PR DESCRIPTION
Without the trailing '0', the command is invalid.