### PR TITLE
Added setup.py to flake8 exclude list

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,5 +23,5 @@ commands = flake8
 commands = nosetests --with-coverage {posargs}
 
 [flake8]
-exclude = .venv*,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*.egg,.update-venv,build
+exclude = .venv*,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*.egg,.update-venv,build,setup.py
 max-line-length = 119


### PR DESCRIPTION
Saw that build `failed` due to `flake8`. Decide to add it to `exclude` list as I can't see any easy way to shorten the `url` that violate `E501 line too long`.