### PR TITLE
Fix str to byte in get_slab_stats

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -349,14 +349,14 @@ class Client(threading.local):
             readline = s.readline
             while 1:
                 line = readline()
-                if not line or line.strip() == 'END':
+                if not line or line.strip() == b'END':
                     break
-                item = line.split(' ', 2)
-                if line.startswith('STAT active_slabs') or line.startswith('STAT total_malloced'):
+                item = line.split(b' ', 2)
+                if line.startswith(b'STAT active_slabs') or line.startswith(b'STAT total_malloced'):
                     serverData[item[1]] = item[2]
                 else:
                     # 0 = STAT, 1 = ITEM, 2 = Value
-                    slab = item[1].split(':', 2)
+                    slab = item[1].split(b':', 2)
                     # 0 = Slab #, 1 = Name
                     if slab[0] not in serverData:
                         serverData[slab[0]] = {}


### PR DESCRIPTION
In Python 3.6.5 and memcached 1.5.10, I use `get_slab_stats` command and get errors below.

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/yasu/.local/share/virtualenvs/python-memcached-mnWCL0QA/lib/python3.6/site-packages/memcache.py", line 354, in get_slab_stats
    item = line.split(' ', 2)
TypeError: a bytes-like object is required, not 'str'
a bytes-like object is required, not 'str'
```

Therefore, I modified `str` to `bytes`.