### PR TITLE
Fix multi_set with tuple keys

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -895,6 +895,9 @@ class Client(threading.local):
         server_keys, prefixed_to_orig_key = self._map_and_prefix_keys(
             six.iterkeys(mapping), key_prefix)
 
+        mapping = dict([(k[1] if type(k) is tuple else k, v)
+                        for k, v in six.iteritems(mapping)])
+
         # send out all requests on each server before reading anything
         dead_servers = []
         notstored = []  # original keys.

--- a/tests/test_setmulti.py
+++ b/tests/test_setmulti.py
@@ -61,11 +61,11 @@ class test_Memcached_Set_Multi(unittest.TestCase):
         socket.socket = self.old_socket
 
     def test_Socket_Disconnect(self):
-        mapping = {'foo': 'FOO', 'bar': 'BAR'}
+        mapping = {'foo': 'FOO', 'bar': 'BAR', (0, 'foobar'): 'FOOBAR'}
         with captured_stderr() as log:
             bad_keys = self.mc.set_multi(mapping)
         self.assertIn('connection closed in readline().', log.getvalue())
-        self.assertEqual(sorted(bad_keys), ['bar', 'foo'])
+        self.assertEqual(sorted(bad_keys), ['bar', 'foo', 'foobar'])
         if DEBUG:
             print('set_multi({0!r}) -> {1!r}'.format(mapping, bad_keys))
 


### PR DESCRIPTION
Multi-set with tuple as keys (with server hash) would otherwise raise exception.