### PR TITLE
Add support for default value in get

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -1440,7 +1440,8 @@ class _Host(object):
         if self.socket:
             recv = self.socket.recv
         else:
-            recv = lambda bufsize: b''
+            def recv(*args, **kwargs):
+                return b''
 
         while True:
             index = buf.find(b'\r\n')

--- a/memcache.py
+++ b/memcache.py
@@ -1059,7 +1059,7 @@ class Client(threading.local):
                 server.mark_dead(msg)
             return 0
 
-    def _get(self, cmd, key):
+    def _get(self, cmd, key, default=None):
         key = self._encode_key(key)
         if self.do_check_key:
             self.check_key(key)
@@ -1088,7 +1088,7 @@ class Client(threading.local):
                     )
 
                 if not rkey:
-                    return None
+                    return default
                 try:
                     value = self._recv_value(server, flags, rlen)
                 finally:
@@ -1113,12 +1113,12 @@ class Client(threading.local):
                 server.mark_dead(msg)
             return None
 
-    def get(self, key):
+    def get(self, key, default=None):
         '''Retrieves a key from the memcache.
 
         @return: The value or None.
         '''
-        return self._get('get', key)
+        return self._get('get', key, default)
 
     def gets(self, key):
         '''Retrieves a key from the memcache. Used in conjunction with 'cas'.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,10 @@ setup(
     maintainer="Sean Reifschneider",
     maintainer_email="jafo@tummy.com",
     url="https://github.com/linsomniac/python-memcached",
-    download_url="https://github.com/linsomniac/python-memcached/releases/download/{0}/python-memcached-{0}.tar.gz".format(version),
+    download_url=(
+        "https://github.com/linsomniac/python-memcached/releases/download/"
+        "{0}/python-memcached-{0}.tar.gz".format(version)
+    ),
     py_modules=["memcache"],
     install_requires=open('requirements.txt').read().split(),
     classifiers=[

--- a/tests/test_memcache.py
+++ b/tests/test_memcache.py
@@ -51,6 +51,20 @@ class TestMemcache(unittest.TestCase):
         self.assertEqual(result, True)
         self.assertEqual(self.mc.get("long"), None)
 
+    def test_default(self):
+        key = "default"
+        default = object()
+        result = self.mc.get(key, default=default)
+        self.assertEqual(result, default)
+
+        self.mc.set("default", None)
+        result = self.mc.get(key, default=default)
+        self.assertIsNone(result)
+
+        self.mc.set("default", 123)
+        result = self.mc.get(key, default=default)
+        self.assertEqual(result, 123)
+
     @mock.patch.object(_Host, 'send_cmd')
     @mock.patch.object(_Host, 'readline')
     def test_touch(self, mock_readline, mock_send_cmd):


### PR DESCRIPTION
This PR adds the `default` keyword argument to `get()` method, which allows to support a custom default value to retrieve from the cache, if a key is not present on the server.

Closes #159