### PR TITLE
Add testing for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
   - pypy
 services:
   - memcached

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27,py34,py35,p36,pypy,pep8
+envlist = py27,py{34,35,36,37},pypy,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
I need some form of python memcached support in Python 3.7.

The tests (in tox) are 100% green for 3.7.