### PR TITLE
test_memcache.py: try import unittest.mock

### DIFF
--- a/tests/test_memcache.py
+++ b/tests/test_memcache.py
@@ -4,7 +4,10 @@ from __future__ import print_function
 import unittest
 import zlib
 
-import mock
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 
 from memcache import Client, _Host, SERVER_MAX_KEY_LENGTH, SERVER_MAX_VALUE_LENGTH  # noqa: H301
 from .utils import captured_stderr


### PR DESCRIPTION
Rather than always require the separate mock module,
try to use unittest.mock if it is available

Signed-off-by: Tim Orling <ticotimo@gmail.com>