### PR TITLE
Python 3.8 syntax warning fix: use == as suggested by Python 3.8

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -1300,8 +1300,8 @@ class Client(threading.local):
             key = key[1]
         if key is None:
             raise Client.MemcachedKeyNoneError("Key is None")
-        if key is '':
-            if key_extra_len is 0:
+        if key == '':
+            if key_extra_len == 0:
                 raise Client.MemcachedKeyNoneError("Key is empty")
 
             #  key is empty but there is some other component to key


### PR DESCRIPTION
```
<snap>/python_memcached-1.59-py3.8.egg/memcache.py:1303:
SyntaxWarning: "is" with a literal. Did you mean "=="?
  if key is '':
<snap>/python_memcached-1.59-py3.8.egg/memcache.py:1304:
SyntaxWarning: "is" with a literal. Did you mean "=="?
  if key_extra_len is 0:
```