### PR TITLE
Fixed return value from delete command.

### DIFF
--- a/memcache.py
+++ b/memcache.py
@@ -552,9 +552,9 @@ class Client(threading.local):
             if noreply:
                 return 1
             line = server.readline()
-            if line and line.strip() in [b'DELETED', b'NOT_FOUND']:
+            if line and line.strip() == b'DELETED':
                 return 1
-            self.debuglog('delete expected DELETED or NOT_FOUND, got: {!r}'.format(line))
+            self.debuglog('delete expected DELETED, got: {!r}'.format(line))
         except OSError as msg:
             if isinstance(msg, tuple):
                 msg = msg[1]

--- a/tests/test_memcache.py
+++ b/tests/test_memcache.py
@@ -56,6 +56,8 @@ class TestMemcache(unittest.TestCase):
         result = self.mc.delete("long")
         self.assertEqual(result, True)
         self.assertEqual(self.mc.get("long"), None)
+        result = self.mc.delete("<missing>")
+        self.assertEqual(result, False)
 
     def test_default(self):
         key = "default"


### PR DESCRIPTION
The `delete()` command currently returns `1` if the response from the server is either `'DELETED'` or `'NOT_FOUND'`. This differs from other implementations, e.g. `pymemcache` and `pylibmc`, and doesn't seem to make sense given that these are the only two documented return types from the protocol for the delete command.

It seems that `delete()` was changed to explicitly consider both responses as successful way back in 2010, but that change only seemed to double down on the behavior that was being reported in the issue. See https://bugs.launchpad.net/python-memcached/+bug/471727. The concern was avoiding breaking backward compatibility.

It was possible to work around this by calling `_deletetouch()` and passing in the `expected` responses, but that was broken by the change to remove `time` in ab668ed17887c956af3e2af89555e31d190ab63d.

~To avoid issues with backward compatibility, I've added a `strict` argument which can be enabled to return a non-successful response from `delete()` for `'NOT_FOUND'`.~

Further, making the change to interpret `'NOT_FOUND'` as `0` doesn't cause any test failures. I've added an assertion to check deletion of a non-existent key ~using both strict and non-strict~.

Fixes #170.