### PR TITLE
Update Python support to 3.10+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/memcache.py
+++ b/memcache.py
@@ -315,11 +315,11 @@ class Client(threading.local):
             if not s.connect():
                 continue
             if s.family == socket.AF_INET:
-                name = '{}:{} ({})'.format(s.ip, s.port, s.weight)
+                name = f'{s.ip}:{s.port} ({s.weight})'
             elif s.family == socket.AF_INET6:
-                name = '[{}]:{} ({})'.format(s.ip, s.port, s.weight)
+                name = f'[{s.ip}]:{s.port} ({s.weight})'
             else:
-                name = 'unix:{} ({})'.format(s.address, s.weight)
+                name = f'unix:{s.address} ({s.weight})'
             if not stat_args:
                 s.send_cmd('stats')
             else:
@@ -344,11 +344,11 @@ class Client(threading.local):
             if not s.connect():
                 continue
             if s.family == socket.AF_INET:
-                name = '{}:{} ({})'.format(s.ip, s.port, s.weight)
+                name = f'{s.ip}:{s.port} ({s.weight})'
             elif s.family == socket.AF_INET6:
-                name = '[{}]:{} ({})'.format(s.ip, s.port, s.weight)
+                name = f'[{s.ip}]:{s.port} ({s.weight})'
             else:
-                name = 'unix:{} ({})'.format(s.address, s.weight)
+                name = f'unix:{s.address} ({s.weight})'
             serverData = {}
             data.append((name, serverData))
             s.send_cmd('stats slabs')
@@ -382,11 +382,11 @@ class Client(threading.local):
             if not s.connect():
                 continue
             if s.family == socket.AF_INET:
-                name = '{}:{} ({})'.format(s.ip, s.port, s.weight)
+                name = f'{s.ip}:{s.port} ({s.weight})'
             elif s.family == socket.AF_INET6:
-                name = '[{}]:{} ({})'.format(s.ip, s.port, s.weight)
+                name = f'[{s.ip}]:{s.port} ({s.weight})'
             else:
-                name = 'unix:{} ({})'.format(s.address, s.weight)
+                name = f'unix:{s.address} ({s.weight})'
             serverData = {}
             data.append((name, serverData))
             s.send_cmd('stats items')
@@ -554,7 +554,7 @@ class Client(threading.local):
             line = server.readline()
             if line and line.strip() == b'DELETED':
                 return 1
-            self.debuglog('delete expected DELETED, got: {!r}'.format(line))
+            self.debuglog(f'delete expected DELETED, got: {line!r}')
         except OSError as msg:
             if isinstance(msg, tuple):
                 msg = msg[1]
@@ -590,7 +590,7 @@ class Client(threading.local):
             line = server.readline()
             if line and line.strip() in [b'TOUCHED']:
                 return 1
-            self.debuglog('touch expected TOUCHED, got: {!r}'.format(line))
+            self.debuglog(f'touch expected TOUCHED, got: {line!r}')
         except OSError as msg:
             if isinstance(msg, tuple):
                 msg = msg[1]
@@ -1388,7 +1388,7 @@ class _Host:
         return 0
 
     def mark_dead(self, reason):
-        self.debuglog("MemCache: {}: {}.  Marking dead.".format(self, reason))
+        self.debuglog(f"MemCache: {self}: {reason}.  Marking dead.")
         self.deaduntil = time.time() + self.dead_retry
         if self.flush_on_reconnect:
             self.flush_on_next_connect = 1
@@ -1404,7 +1404,7 @@ class _Host:
             s.settimeout(self.socket_timeout)
         try:
             s.connect(self.address)
-        except socket.timeout as msg:
+        except TimeoutError as msg:
             self.mark_dead("connect: %s" % msg)
             return None
         except OSError as msg:
@@ -1516,7 +1516,7 @@ class _Host:
         elif self.family == socket.AF_INET6:
             return "inet6:[%s]:%d%s" % (self.address[0], self.address[1], d)
         else:
-            return "unix:{}{}".format(self.address, d)
+            return f"unix:{self.address}{d}"
 
 
 def _doctest():
@@ -1527,7 +1527,7 @@ def _doctest():
     globs = {"mc": mc}
     results = doctest.testmod(memcache, globs=globs)
     mc.disconnect_all()
-    print("Doctests: {}".format(results))
+    print(f"Doctests: {results}")
     if results.failed:
         sys.exit(1)
 

--- a/memcache.py
+++ b/memcache.py
@@ -506,8 +506,6 @@ class Client(threading.local):
                 server.send_cmds(b''.join(bigcmd))
             except OSError as msg:
                 rc = 0
-                if isinstance(msg, tuple):
-                    msg = msg[1]
                 server.mark_dead(msg)
                 dead_servers.append(server)
 
@@ -524,8 +522,6 @@ class Client(threading.local):
                 for key in keys:
                     server.expect(b"DELETED")
             except OSError as msg:
-                if isinstance(msg, tuple):
-                    msg = msg[1]
                 server.mark_dead(msg)
                 rc = 0
         return rc
@@ -556,8 +552,6 @@ class Client(threading.local):
                 return 1
             self.debuglog(f'delete expected DELETED, got: {line!r}')
         except OSError as msg:
-            if isinstance(msg, tuple):
-                msg = msg[1]
             server.mark_dead(msg)
         return 0
 
@@ -592,8 +586,6 @@ class Client(threading.local):
                 return 1
             self.debuglog(f'touch expected TOUCHED, got: {line!r}')
         except OSError as msg:
-            if isinstance(msg, tuple):
-                msg = msg[1]
             server.mark_dead(msg)
         return 0
 
@@ -666,8 +658,6 @@ class Client(threading.local):
                 return None
             return int(line)
         except OSError as msg:
-            if isinstance(msg, tuple):
-                msg = msg[1]
             server.mark_dead(msg)
             return None
 
@@ -937,8 +927,6 @@ class Client(threading.local):
                         notstored.append(prefixed_to_orig_key[key])
                 server.send_cmds(b''.join(bigcmd))
             except OSError as msg:
-                if isinstance(msg, tuple):
-                    msg = msg[1]
                 server.mark_dead(msg)
                 dead_servers.append(server)
 
@@ -963,8 +951,6 @@ class Client(threading.local):
                         # un-mangle.
                         notstored.append(prefixed_to_orig_key[key])
             except (_Error, OSError) as msg:
-                if isinstance(msg, tuple):
-                    msg = msg[1]
                 server.mark_dead(msg)
         return notstored
 
@@ -1052,8 +1038,6 @@ class Client(threading.local):
                     return True
                 return server.expect(b"STORED", raise_exception=True) == b"STORED"
             except OSError as msg:
-                if isinstance(msg, tuple):
-                    msg = msg[1]
                 server.mark_dead(msg)
             return 0
 
@@ -1103,8 +1087,6 @@ class Client(threading.local):
                 finally:
                     server.expect(b"END", raise_exception=True)
             except (_Error, OSError) as msg:
-                if isinstance(msg, tuple):
-                    msg = msg[1]
                 server.mark_dead(msg)
                 return None
 
@@ -1203,8 +1185,6 @@ class Client(threading.local):
                 fullcmd = b"get " + b" ".join(server_keys[server])
                 server.send_cmd(fullcmd)
             except OSError as msg:
-                if isinstance(msg, tuple):
-                    msg = msg[1]
                 server.mark_dead(msg)
                 dead_servers.append(server)
 
@@ -1225,8 +1205,6 @@ class Client(threading.local):
                         retvals[prefixed_to_orig_key[rkey]] = val
                     line = server.readline()
             except (_Error, OSError) as msg:
-                if isinstance(msg, tuple):
-                    msg = msg[1]
                 server.mark_dead(msg)
         return retvals
 
@@ -1408,8 +1386,6 @@ class _Host:
             self.mark_dead("connect: %s" % msg)
             return None
         except OSError as msg:
-            if isinstance(msg, tuple):
-                msg = msg[1]
             self.mark_dead("connect: %s" % msg)
             return None
         self.socket = s

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 
+import re
 from setuptools import setup  # noqa
-from setuptools.depends import get_module_constant
 
 dl_url = "https://github.com/linsomniac/python-memcached/releases/download/{0}/python-memcached-{0}.tar.gz"
 
-version = get_module_constant("memcache", "__version__")
+version = re.search(
+    r'^__version__ = ["\']([^"\']+)["\']',
+    open("memcache.py", encoding="utf-8").read(),
+    re.M,
+).group(1)
 setup(
     name="python-memcached",
     version=version,
@@ -32,10 +36,10 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 pytest
 coverage
 hacking
-mock

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-nose
+pytest
 coverage
 hacking
 mock

--- a/tests/test_memcache.py
+++ b/tests/test_memcache.py
@@ -1,19 +1,16 @@
-# -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import unittest
 import zlib
 
 try:
     import unittest.mock as mock
 except ImportError:
-    import mock
+    from unittest import mock
 
 from memcache import Client, _Host, SERVER_MAX_KEY_LENGTH, SERVER_MAX_VALUE_LENGTH  # noqa: H301
 from .utils import captured_stderr
 
 
-class FooStruct(object):
+class FooStruct:
 
     def __init__(self):
         self.bar = "baz"
@@ -151,7 +148,7 @@ class TestMemcache(unittest.TestCase):
         self.check_setget("bool", True)
 
     def test_unicode_key(self):
-        s = u'\u4f1a'
+        s = '\u4f1a'
         maxlen = SERVER_MAX_KEY_LENGTH // len(s.encode('utf-8'))
         key = s * maxlen
 
@@ -161,7 +158,7 @@ class TestMemcache(unittest.TestCase):
 
     def test_unicode_value(self):
         key = 'key'
-        value = u'Iñtërnâtiônàlizætiøn2'
+        value = 'Iñtërnâtiônàlizætiøn2'
         self.mc.set(key, value)
         cached_value = self.mc.get(key)
         self.assertEqual(value, cached_value)

--- a/tests/test_memcache.py
+++ b/tests/test_memcache.py
@@ -1,10 +1,7 @@
 import unittest
 import zlib
 
-try:
-    import unittest.mock as mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 from memcache import Client, _Host, SERVER_MAX_KEY_LENGTH, SERVER_MAX_VALUE_LENGTH  # noqa: H301
 from .utils import captured_stderr

--- a/tests/test_setmulti.py
+++ b/tests/test_setmulti.py
@@ -7,7 +7,6 @@
 #
 #     https://github.com/linsomniac/python-unittest-skeleton
 
-from __future__ import print_function
 
 import socket
 import sys
@@ -25,19 +24,19 @@ class test_Memcached_Set_Multi(unittest.TestCase):
     def setUp(self):
         RECV_CHUNKS = [b'chunk1']
 
-        class FakeSocket(object):
+        class FakeSocket:
             def __init__(self, *args):
                 if DEBUG:
-                    print('FakeSocket{0!r}'.format(args))
+                    print(f'FakeSocket{args!r}')
                 self._recv_chunks = list(RECV_CHUNKS)
 
             def connect(self, *args):
                 if DEBUG:
-                    print('FakeSocket.connect{0!r}'.format(args))
+                    print(f'FakeSocket.connect{args!r}')
 
             def sendall(self, *args):
                 if DEBUG:
-                    print('FakeSocket.sendall{0!r}'.format(args))
+                    print(f'FakeSocket.sendall{args!r}')
 
             def recv(self, *args):
                 if self._recv_chunks:
@@ -45,7 +44,7 @@ class test_Memcached_Set_Multi(unittest.TestCase):
                 else:
                     data = ''
                 if DEBUG:
-                    print('FakeSocket.recv{0!r} -> {1!r}'.format(args, data))
+                    print(f'FakeSocket.recv{args!r} -> {data!r}')
                 return data
 
             def close(self):
@@ -67,7 +66,7 @@ class test_Memcached_Set_Multi(unittest.TestCase):
         self.assertIn('connection closed in readline().', log.getvalue())
         self.assertEqual(sorted(bad_keys), ['bar', 'foo'])
         if DEBUG:
-            print('set_multi({0!r}) -> {1!r}'.format(mapping, bad_keys))
+            print(f'set_multi({mapping!r}) -> {bad_keys!r}')
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-minversion = 1.6
-envlist = py{36,37,38,39,310,311,312},pypy,pep8
+envlist = py{310,311,312,313,314},pep8
 skipsdist = True
 
 [testenv]
@@ -10,18 +9,15 @@ install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =
-    nosetests {posargs}
+    pytest {posargs}
     python -c 'import memcache; memcache._doctest()'
-
-[tox:jenkins]
-downloadcache = ~/cache/pip
 
 [testenv:pep8]
 commands = flake8
 
 [testenv:cover]
-commands = nosetests --with-coverage {posargs}
+commands = pytest --cov {posargs}
 
 [flake8]
-exclude = .venv*,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*.egg,.update-venv,build
+exclude = venv*,.venv*,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*.egg,.update-venv,build
 max-line-length = 119


### PR DESCRIPTION
- Drops support for Python 3.9 and below
- Adds support for 3.14
- Removes the backports and shims
- Replaces nose for pytest for test runner

Sorry for the duplicate PR. I dropped the other change around setting a specific encoding as it seemed silly on re-review.